### PR TITLE
Validated jump targets for JUMP 0

### DIFF
--- a/tools/8087mc/bin/8087.md
+++ b/tools/8087mc/bin/8087.md
@@ -200,13 +200,13 @@ There are two that are seemingly related to each other, but I don't know what th
 
 Far calls and jumps have 22 targets they can go to, numbered from J0 to J21. Here's everything I know so far.
 
-J0: Probably calls J1/J2/J3 depending on whether it's FADD/FSUB, FMUL or FDIV.
+J0: Calls J1 for FMUL, J2 for FADD/FSUB/FSUBR, or J3 for FDIV/FDIVR.
 
-J1: FMUL ?
+J1: FMUL
 
-J2: FDIV ?
+J2: FADD/FSUB/FSUBR
 
-J3: FADD/FSUB ? 29 lines + calls J11
+J3: FDIV/FDIVR. 29 lines + calls J11
 
 J4: Loads f32 and f64
 


### PR DESCRIPTION
Note that J2 and J3 are switched compared to before.