### PR TITLE
Add two more source values

### DIFF
--- a/tools/8087mc/bin/8087.md
+++ b/tools/8087mc/bin/8087.md
@@ -16,6 +16,10 @@ The `P` bit provides assorted adjustments to some operations. `I` and `J` are so
 
 List of known register indices:
 
+0x00: shift count (source only)
+
+0x01: exp convert logic (source only)
+
 0x02: st(0) w/tag
 
 0x03: st(i) w/tag


### PR DESCRIPTION
0x00 is the shift counter, which can be loaded from the leading zero counter. 0x01 is the exponent convert logic, which according to the patent generates a corrected exponent based on leading zeros.